### PR TITLE
Switch badges for Rockets - Conditional components

### DIFF
--- a/src/components/Rocket.js
+++ b/src/components/Rocket.js
@@ -17,7 +17,10 @@ function Rocket({
         <img className="rocket__image" src={image} alt={id} />
         <div className="rocket__info">
           <h2 className="rocket__title">{name}</h2>
-          <p className="rocket__description">{description}</p>
+          <p className="rocket__description">
+            {reserved && (<strong>RESERVED</strong>)}
+            {description}
+          </p>
           <button onClick={handleClick} type="button">
             {reserved ? 'Cancel Reservation' : 'Reserve Rocket'}
           </button>


### PR DESCRIPTION
## Description ✏️
Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket".